### PR TITLE
Prevent JavaScript error when crawler injects a bad rowId

### DIFF
--- a/resources/web/signaldata/ResultUpdate/resultupdate.js
+++ b/resources/web/signaldata/ResultUpdate/resultupdate.js
@@ -34,7 +34,12 @@ var getResultData = function(assay) {
         requiredVersion: 13.2,
         filterArray: [LABKEY.Filter.create('RowId', LABKEY.ActionURL.getParameter('rowId'))],
         success: function(results){
-            init(assay, results.getRow(0));
+            if (results.length > 0) {
+                init(assay, results.getRow(0));
+            }
+            else {
+                alert("Row not found");
+            }
         },
         scope: this
     });


### PR DESCRIPTION
#### Rationale
The crawler's injects bad URL parameters. `resultupdate.js` throws a JavaScript error when a bad rowId is provided:
```
Error: No row found for index 0
  getRow (webpack://@labkey/api/src/labkey/query/Response.ts:215:14)
  success (http://localhost:8111/labkey/signaldata/ResultUpdate/resultupdate.js:37:33)
```

#### Changes
* Throw an alert if `selectRows` doesn't return any rows
