### PR TITLE
Avoid using raw JS alert() to stop tripping up the crawler

### DIFF
--- a/resources/web/signaldata/ResultUpdate/resultupdate.js
+++ b/resources/web/signaldata/ResultUpdate/resultupdate.js
@@ -38,7 +38,8 @@ var getResultData = function(assay) {
                 init(assay, results.getRow(0));
             }
             else {
-                alert("Row not found");
+                // Use an ExtJS alert instead of a raw browser alert to avoid alarming the crawler
+                Ext4.Msg.alert('Error', 'Row not found');
             }
         },
         scope: this


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_GitPostgres/1860445?hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false&expandBuildChangesSection=true

A previous attempt at a fix introduced this alert() to avoid JS console errors, but the alert still freaks out the crawler.

#### Changes
* Use ExtJS alert to fly under the crawler's radar