### PR TITLE
Remove `WebDriverWrapper.setDropZone`

### DIFF
--- a/test/src/org/labkey/test/pages/signaldata/SignalDataUploadPage.java
+++ b/test/src/org/labkey/test/pages/signaldata/SignalDataUploadPage.java
@@ -50,7 +50,7 @@ public class SignalDataUploadPage
     public void uploadFile(File... file)
     {
         WebElement dropFileInputEl = Locators.dropFileInput.findElement(_test.getDriver());
-        _test.setDropZone(dropFileInputEl, Arrays.asList(file));
+        _test.setInput(dropFileInputEl, Arrays.asList(file));
     }
 
     public void uploadIncorrectFile(File file)

--- a/test/src/org/labkey/test/pages/signaldata/SignalDataUploadPage.java
+++ b/test/src/org/labkey/test/pages/signaldata/SignalDataUploadPage.java
@@ -22,6 +22,7 @@ import org.labkey.test.components.ext4.Window;
 import org.labkey.test.util.Ext4Helper;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
 import java.util.Arrays;
@@ -50,6 +51,8 @@ public class SignalDataUploadPage
     public void uploadFile(File... file)
     {
         WebElement dropFileInputEl = Locators.dropFileInput.findElement(_test.getDriver());
+        _test.executeScript("arguments[0].setAttribute('class', '');arguments[0].setAttribute('style', '');", dropFileInputEl);
+        _test.shortWait().until(ExpectedConditions.elementToBeClickable(dropFileInputEl));
         _test.setInput(dropFileInputEl, Arrays.asList(file));
     }
 

--- a/test/src/org/labkey/test/tests/signaldata/SignalDataRawTest.java
+++ b/test/src/org/labkey/test/tests/signaldata/SignalDataRawTest.java
@@ -135,6 +135,7 @@ public class SignalDataRawTest extends BaseWebDriverTest
                 getFile(ASSAY_DATA_LOC + "/" + RESULT_FILENAME_1),
                 getFile(ASSAY_DATA_LOC + "/" + RESULT_FILENAME_2),
                 getFile(ASSAY_DATA_LOC + "/" + RESULT_FILENAME_3));
+        uploadPage.waitForProgressBars(3);
         log("Attempting to upload a data file not specified in metadata");
         uploadPage.uploadIncorrectFile(getFile(ASSAY_DATA_LOC + "/" + "BLANK235.TXT"));
 


### PR DESCRIPTION
#### Rationale
This is the sole use of the special `setDropZone` method and this component works without it.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1201

#### Changes
* Use `setInput` instead of `setDropZone`
