### PR TITLE
Work around race condition in signal data upload form

### DIFF
--- a/test/src/org/labkey/test/pages/signaldata/SignalDataUploadPage.java
+++ b/test/src/org/labkey/test/pages/signaldata/SignalDataUploadPage.java
@@ -52,6 +52,7 @@ public class SignalDataUploadPage
 
     public void uploadFile(File... file)
     {
+        sleep(1_000);
         WebElement dropFileInputEl = Locators.dropFileInput.findElement(_test.getDriver());
         _test.setInput(dropFileInputEl, Arrays.asList(file));
     }
@@ -62,7 +63,7 @@ public class SignalDataUploadPage
                 Locator.byClass("x4-progress-bar").withAttribute("style", "width:100%")
                         .findElements(_test.getDriver()).size() == count,
                 "Upload didn't finish.", 5_000);
-        sleep(500); // Just a little extra.
+        sleep(1_000);
     }
 
     public void uploadIncorrectFile(File file)
@@ -71,6 +72,7 @@ public class SignalDataUploadPage
         WebElement msgBox = Locators.fileNotUploadedMsgBox(file.getName()).waitForElement(_test.getDriver(), WAIT_FOR_JAVASCRIPT);
         msgBox.sendKeys(Keys.ESCAPE);
         _test.shortWait().until(ExpectedConditions.invisibilityOf(msgBox));
+        sleep(1_000);
     }
 
     public void deleteFile(String fileName)
@@ -106,7 +108,6 @@ public class SignalDataUploadPage
     {
         WebElement saveButton = Locators.saveButton.findElement(_test.getDriver());
         WebDriverWrapper.waitFor(() -> !saveButton.getAttribute("class").contains("disabled"), "Unable to save, button is disabled", 1000);
-        sleep(500); // Just a little extra wait. Getting a 404 from the 'MOVE' command when attempting to save too quickly
         _test.clickAndWait(Locators.saveButton);
     }
 

--- a/test/src/org/labkey/test/tests/signaldata/SignalDataRawTest.java
+++ b/test/src/org/labkey/test/tests/signaldata/SignalDataRawTest.java
@@ -129,6 +129,10 @@ public class SignalDataRawTest extends BaseWebDriverTest
 
         log("Uploading metadata file");
         uploadPage.uploadMetadataFile(METADATA_FILE);
+
+        log("Attempting to upload a data file not specified in metadata");
+        uploadPage.uploadIncorrectFile(getFile(ASSAY_DATA_LOC + "/" + "BLANK235.TXT"));
+
         log("Uploading data files");
         int uploadCount = 3;
         uploadPage.uploadFile(
@@ -136,8 +140,6 @@ public class SignalDataRawTest extends BaseWebDriverTest
                 getFile(ASSAY_DATA_LOC + "/" + RESULT_FILENAME_2),
                 getFile(ASSAY_DATA_LOC + "/" + RESULT_FILENAME_3));
         uploadPage.waitForProgressBars(3);
-        log("Attempting to upload a data file not specified in metadata");
-        uploadPage.uploadIncorrectFile(getFile(ASSAY_DATA_LOC + "/" + "BLANK235.TXT"));
 
 // TODO: Not clear what delete should do- just make file unavailable?
 //        log("Delete a file");


### PR DESCRIPTION
#### Rationale
The JavaScript fileSystem commands used by this form get messed up if the test blasts through too fast. Just need to slow down a bit.

#### Related Pull Requests
* N/A

#### Changes
* Add some delays after uploading files
