### PR TITLE
Signal Data Update

### DIFF
--- a/resources/assay/signalData/views/begin.html
+++ b/resources/assay/signalData/views/begin.html
@@ -3,7 +3,7 @@
     <span id="manage-signaldata-link"></span>
     <div id="runsResult"></div>
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<%=scriptNonce%>">
     (function() {
 
         function init() {

--- a/resources/assay/signalData/views/upload.html
+++ b/resources/assay/signalData/views/upload.html
@@ -1,5 +1,5 @@
 <div id="signaldata-upload-content"></div>
-<script type="application/javascript">
+<script type="application/javascript" nonce="<%=scriptNonce%>">
     var wp = new LABKEY.WebPart({
         renderTo: 'signaldata-upload-content',
         partName: 'Signal Data Upload',

--- a/resources/views/mockSignalDataWatch.html
+++ b/resources/views/mockSignalDataWatch.html
@@ -1,7 +1,7 @@
 <input type="button" class="signaldata-run-btn" value="Load Assay Samples">
 <div class="signaldata-error-log" style="color: red;"></div>
 <div><ul class="signaldata-status-log"></ul></div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<%=scriptNonce%>">
 
     (function() {
 

--- a/resources/views/qc.html
+++ b/resources/views/qc.html
@@ -1,5 +1,5 @@
 <div id="qctool"></div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<%=scriptNonce%>">
 
     Ext4.onReady(function() {
         Ext4.create('LABKEY.SignalData.QualityControl', {

--- a/resources/views/signalDataUpload.html
+++ b/resources/views/signalDataUpload.html
@@ -30,7 +30,7 @@
     <div class="signaldata-upload-result-files"></div>
 
 
-<script type="application/javascript">
+<script type="application/javascript" nonce="<%=scriptNonce%>">
     (function($) {
         var context = <%=webpartContext%>;
         var metadataFormElId = LABKEY.Utils.id();

--- a/resources/views/signalDataUpload.html
+++ b/resources/views/signalDataUpload.html
@@ -13,8 +13,8 @@
             <tr>
                 <td class="labkey-form-label" style="width: 100px;">Upload Type:</td>
                 <td>
-                    <input type="radio" name="uploadType" value="paste"  onchange="LABKEY.SignalData.disableFileUpload()">Cut/Paste<br/>
-                    <input type="radio" name="uploadType" value="file" checked="checked" onchange="LABKEY.SignalData.enableFileUpload()">File
+                    <input type="radio" name="uploadType" value="paste" id="upload-type-paste">Cut/Paste<br/>
+                    <input type="radio" name="uploadType" value="file" id="upload-type-file" checked="checked">File
                 </td>
             </tr>
             <tr>
@@ -32,22 +32,28 @@
 
 <script type="application/javascript" nonce="<%=scriptNonce%>">
     (function($) {
-        var context = <%=webpartContext%>;
-        var metadataFormElId = LABKEY.Utils.id();
-        var metadataFileId = LABKEY.Utils.id();
-        var metadataTSVId = LABKEY.Utils.id();
-        var buttonId = LABKEY.Utils.id();
-        var fileUploadElementId = LABKEY.Utils.id();
-        var templateDivId = LABKEY.Utils.id();
+        LABKEY.Utils.onReady(function(){
+            var context = <%=webpartContext%>;
+            var metadataFormElId = LABKEY.Utils.id();
+            var metadataFileId = LABKEY.Utils.id();
+            var metadataTSVId = LABKEY.Utils.id();
+            var buttonId = LABKEY.Utils.id();
+            var fileUploadElementId = LABKEY.Utils.id();
+            var templateDivId = LABKEY.Utils.id();
 
-        $('#' + context.wrapperDivId + ' .signaldata-upload-target').attr('id', metadataFormElId);
-        $('#' + context.wrapperDivId + ' .signaldata-upload-file').attr('id', metadataFileId);
-        $('#' + context.wrapperDivId + ' .signaldata-upload-tsv').attr('id', metadataTSVId);
-        $('#' + context.wrapperDivId + ' .signaldata-upload-button').attr('id', buttonId);
-        $('#' + context.wrapperDivId + ' .signaldata-upload-result-files').attr('id', fileUploadElementId);
-        $('#' + context.wrapperDivId + ' .signaldata-upload-templatelink').attr('id', templateDivId);
+            $('#' + context.wrapperDivId + ' .signaldata-upload-target').attr('id', metadataFormElId);
+            $('#' + context.wrapperDivId + ' .signaldata-upload-file').attr('id', metadataFileId);
+            $('#' + context.wrapperDivId + ' .signaldata-upload-tsv').attr('id', metadataTSVId);
+            $('#' + context.wrapperDivId + ' .signaldata-upload-button').attr('id', buttonId);
+            $('#' + context.wrapperDivId + ' .signaldata-upload-result-files').attr('id', fileUploadElementId);
+            $('#' + context.wrapperDivId + ' .signaldata-upload-templatelink').attr('id', templateDivId);
 
-        LABKEY.SignalData.initializeUploadForm(metadataFormElId, metadataFileId, metadataTSVId, buttonId, fileUploadElementId, templateDivId);
+            // register click handlers
+            $('#upload-type-paste').on('click', function(){LABKEY.SignalData.disableFileUpload();});
+            $('#upload-type-file').on('click', function(){LABKEY.SignalData.enableFileUpload();});
+
+            LABKEY.SignalData.initializeUploadForm(metadataFormElId, metadataFileId, metadataTSVId, buttonId, fileUploadElementId, templateDivId);
+        });
 
     })(jQuery);
 </script>

--- a/resources/web/signaldata/QCView/DataService.js
+++ b/resources/web/signaldata/QCView/DataService.js
@@ -75,7 +75,7 @@ Ext4.define('LABKEY.SignalData.DataService', {
                 //
                 if (xleft == 0 && xright == 0) {
                     for (d=0; d < _data.length; d++) {
-                        xy = _data[d][0].split(' ');
+                        xy = this.getXYRow(_data[d]);
                         xy[0] = parseFloat(xy[0]);
                         xy[1] = parseFloat(xy[1]);
                         newData.push(xy);
@@ -86,7 +86,7 @@ Ext4.define('LABKEY.SignalData.DataService', {
                     // using bounds
                     //
                     for (d=0; d < _data.length; d++) {
-                        xy = _data[d][0].split(' ');
+                        xy = this.getXYRow(_data[d]);
                         xy[0] = parseFloat(xy[0]);
                         xy[1] = parseFloat(xy[1]);
                         if (xy[0] > xleft && xy[0] < xright)
@@ -101,7 +101,7 @@ Ext4.define('LABKEY.SignalData.DataService', {
                 if (xleft == 0 && xright == 0) {
                     for (d=0; d < _data.length; d++) {
                         if (d%mod == 0) {
-                            xy = _data[d][0].split(' ');
+                            xy = this.getXYRow(_data[d]);
                             xy[0] = parseFloat(xy[0]);
                             xy[1] = parseFloat(xy[1]);
                             newData.push(xy);
@@ -114,7 +114,7 @@ Ext4.define('LABKEY.SignalData.DataService', {
                     //
                     for (d=0; d < _data.length; d++) {
                         if (d%mod == 0) {
-                            xy = _data[d][0].split(' ');
+                            xy = this.getXYRow(_data[d]);
                             xy[0] = parseFloat(xy[0]);
                             xy[1] = parseFloat(xy[1]);
                             if (xy[0] > xleft && xy[0] < xright)
@@ -127,6 +127,19 @@ Ext4.define('LABKEY.SignalData.DataService', {
             data = newData;
         }
         return data;
+    },
+
+    /**
+     * Helper to return an XY array from the raw input data file. This helps normalize
+     * different data file delimiter types.
+     */
+    getXYRow : function(row) {
+        // space delimited
+        if (row.length === 1)
+            return row[0].split(' ');
+
+        // all others
+        return row;
     },
 
     /**
@@ -147,7 +160,7 @@ Ext4.define('LABKEY.SignalData.DataService', {
 
                 for (d = 0; d < _data.length; d++)
                 {
-                    xy = _data[d][0].split(' ');
+                    xy = this.getXYRow(_data[d]);
                     y = parseFloat(xy[1]);
                     if (y > maxY)
                     {

--- a/resources/web/signaldata/QCView/DataService.js
+++ b/resources/web/signaldata/QCView/DataService.js
@@ -25,7 +25,7 @@ Ext4.define('LABKEY.SignalData.DataService', {
             if (content)
             {
                 if (Ext4.isFunction(callback))
-                    callback.call(scope || this, content);
+                    callback.call(scope || this, content, expData);
             }
             else
             {
@@ -35,7 +35,7 @@ Ext4.define('LABKEY.SignalData.DataService', {
                     {
                         this._ContentCache[path] = c;
                         if (Ext4.isFunction(callback))
-                            callback.call(scope || this, c);
+                            callback.call(scope || this, c, expData);
                     },
                     failure: function (error)
                     {
@@ -61,7 +61,7 @@ Ext4.define('LABKEY.SignalData.DataService', {
     getData : function(datacontent, xleft, xright, mod) {
         var data = [];
         if (datacontent) {
-            var _data = datacontent.sheets[0].data;
+            var _data = [...datacontent.sheets[0].data];
             _data.shift(); // get rid of column headers
             var newData = [], d, xy;
 

--- a/resources/web/signaldata/QCView/SampleCreator.js
+++ b/resources/web/signaldata/QCView/SampleCreator.js
@@ -285,10 +285,11 @@ Ext4.define('LABKEY.SignalData.SampleCreator', {
                     allContent = [],
                     contentMap = {};
 
-                var done = function(content) {
+                var done = function(content, pr) {
                     received++;
+                    content.runName = pr.runName;
                     allContent.push(content);
-                    contentMap[content.fileName] = content;
+                    contentMap[pr.runName] = content;
                     if (received == expected) {
                         this.allContent = allContent;
                         this.contentMap = contentMap;
@@ -296,15 +297,17 @@ Ext4.define('LABKEY.SignalData.SampleCreator', {
                     }
                 };
 
-                for (var d=0; d < provisionalRuns.length; d++) {
-                    var pr = provisionalRuns[d].get('expDataRun');
+                Ext4.each(provisionalRuns, function(run){
+                    var pr = run.get('expDataRun');
                     if (pr) {
+                        // use the run name as the key for all data
+                        pr.runName = run.get('name');
                         SignalDataService.FileContentCache(pr, done, this);
                     }
                     else {
                         console.error('Failed to load expDataRun from provisional run.');
                     }
-                }
+                }, this);
 
             }, this);
         }
@@ -449,7 +452,7 @@ Ext4.define('LABKEY.SignalData.SampleCreator', {
         var modelname = sample.get('name');
 
         if (modelname) {
-            this.highlighted = sample.get('name') + '.'  + sample.get('fileExt');
+            this.highlighted = sample.get('name');
             this.renderPlot(this.allContent);
         }
     },
@@ -481,7 +484,7 @@ Ext4.define('LABKEY.SignalData.SampleCreator', {
                 include = this._getNode(view, model, 'input[name="include"]');
                 response = this._getNode(view, model, 'span[name="response"]');
 
-                var fileContent = this.contentMap[model.get('name') + '.' + model.get('fileExt')];
+                var fileContent = this.contentMap[model.get('name')];
                 var data = SignalDataService.getData(fileContent, xleft, xright, false);
                 var aucPeak = LABKEY.SignalData.Stats.getAUC(data, base);
                 response.update(+aucPeak.auc.toFixed(3));

--- a/resources/web/signaldata/QCView/SpectrumPlot.js
+++ b/resources/web/signaldata/QCView/SpectrumPlot.js
@@ -64,7 +64,7 @@ Ext4.define('LABKEY.SignalData.SpectrumPlot', {
             color = colors[c%colors.length];
 
             if (useHighlight) {
-                isHighlight = (this.highlight === contents[i].fileName);
+                isHighlight = (this.highlight === contents[i].runName);
 
                 if (!isHighlight) {
                     color = '#A09C9C';

--- a/resources/web/signaldata/UploadView/UploadLog.js
+++ b/resources/web/signaldata/UploadView/UploadLog.js
@@ -276,7 +276,7 @@ Ext4.define('LABKEY.SignalData.UploadLog', {
             function done(file, results) {
 
                 var store = me.getStore();
-                var idx = store.findExact(me.DATA_FILE, file.text);
+                var idx = store.find(me.DATA_FILE, file.text);
                 var process = store.getAt(idx);
 
                 //Set upload time
@@ -411,7 +411,7 @@ Ext4.define('LABKEY.SignalData.UploadLog', {
     workingDirectory: '',
     containsFile: function(file) {
         var store = this.getStore();
-        var idx = store.findExact(this.DATA_FILE, file.name);
+        var idx = store.find(this.DATA_FILE, file.name);
         return store.getAt(idx);
     }
 });

--- a/resources/web/signaldata/UploadView/uploadResultFiles.js
+++ b/resources/web/signaldata/UploadView/uploadResultFiles.js
@@ -192,7 +192,7 @@ LABKEY.SignalData.initializeDataFileUploadForm = function (metadataFormId, eleme
 
                         //get modelInstance from store that matches file.name
                         var store = uploadLog.getStore();
-                        var idx = store.findExact('DataFile', file.name);
+                        var idx = store.find('DataFile', file.name);
                         var process = store.getAt(idx);
 
                         //Set upload time
@@ -354,8 +354,16 @@ LABKEY.SignalData.initializeDataFileUploadForm = function (metadataFormId, eleme
             },
             success: function() {
                 clearCachedReports(false, function() {
+                    let returnUrl = LABKEY.ActionURL.getReturnUrl();
+                    if (returnUrl) {
+                        if (window.location.hash)
+                            returnUrl = returnUrl.concat(window.location.hash);
+                    }
+                    else {
+                        returnUrl = LABKEY.ActionURL.buildURL('assay', 'assayBegin', null, {rowId: assay.id});
+                    }
                     uploadLog.workingDirectory = setWorkingDirectory();
-                    window.location = LABKEY.ActionURL.buildURL('assay', 'assayBegin', null, {rowId: assay.id});
+                    window.location = returnUrl;
                 },this);
             },
             failure: function(response){


### PR DESCRIPTION
#### Rationale
Initial work to re-enable the `signalData` module with some initial improvements / bug fixes to allow it to be used either stand alone or through the Biologics application. A separate PR creates the client specific distribution to include this module.

Change:
- Fixes for CSP violations
- Data files can now be tab, comma and space delimited
- Run metadata improvements:
  -  Metadata `name` and `dataFile` values no longer have to match exactly.  The name can be changed in either the metadata file or in the upload grid and the app should respect that keying. Previously, the highlighting and AUC calculation did not work properly in this scenario.
  - `dataFile` file name no longer needs to match exactly by case.
- Fixed an issue where the `AUC` peak calculation would change by repeatedly clicking on the "C" button.
- Respect the `returnUrl` parameter on the import action. This allows redirect back to an app when initiated from that origin.

#### Related Pull Requests
https://github.com/LabKey/distributions/pull/479