### PR TITLE
Issue 50861: Pass around properly encoded WebDav URLs

### DIFF
--- a/resources/views/mockSignalDataWatch.html
+++ b/resources/views/mockSignalDataWatch.html
@@ -218,7 +218,7 @@
                     LABKEY.Ajax.request({
                         url: LABKEY.ActionURL.buildURL('signaldata', 'getSignalDataResource.api'),
                         method: 'POST',
-                        params: { path: file.id, test: true },
+                        params: { path: decodeURIComponent(file.id), test: true },
                         success: function(response) {
                             done(file, Ext4.decode(response.responseText));
                         }

--- a/resources/web/signaldata/ResultUpdate/resultupdate.js
+++ b/resources/web/signaldata/ResultUpdate/resultupdate.js
@@ -64,7 +64,7 @@ var init = function(assay, row){
             LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL('SignalData', 'getSignalDataResource.api'),
                 method: 'POST',
-                params: {path: file.internalId, test: true},
+                params: {path: decodeURIComponent(file.internalId), test: true},
                 success: function (response) {
                     var fileResource = Ext4.decode(response.responseText);
                     var updatedRow = setRunFields(form, fileResource);

--- a/resources/web/signaldata/UploadView/UploadLog.js
+++ b/resources/web/signaldata/UploadView/UploadLog.js
@@ -296,7 +296,7 @@ Ext4.define('LABKEY.SignalData.UploadLog', {
                 LABKEY.Ajax.request({
                     url: LABKEY.ActionURL.buildURL('SignalData', 'getSignalDataResource.api'),
                     method: 'POST',
-                    params: {path: file.id, test: true},
+                    params: {path: decodeURIComponent(file.id), test: true},
                     success: function (response) {
                         done(file, Ext4.decode(response.responseText));
                     },

--- a/src/org/labkey/signaldata/SignalDataController.java
+++ b/src/org/labkey/signaldata/SignalDataController.java
@@ -43,6 +43,7 @@ import org.springframework.validation.BindException;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -75,14 +76,14 @@ public class SignalDataController extends SpringActionController
             PipeRoot root = PipelineService.get().findPipelineRoot(getContainer());
 
             String containerPath = null;
-            String webdavURL = null;
+            URI webdavURL = null;
 
             if (null != root)
             {
                 containerPath = root.getContainer().getPath();
                 webdavURL = root.getWebdavURL();
-                if (SignalDataAssayDataHandler.NAMESPACE.length() > 0)
-                    webdavURL += SignalDataAssayDataHandler.NAMESPACE;
+                if (!SignalDataAssayDataHandler.NAMESPACE.isEmpty())
+                    webdavURL = webdavURL.resolve(SignalDataAssayDataHandler.NAMESPACE);
 
                 //Create folder if needed
                 File sdFileRoot = new File(root.getRootPath(), SignalDataAssayDataHandler.NAMESPACE);
@@ -91,7 +92,7 @@ public class SignalDataController extends SpringActionController
             }
 
             resp.put("containerPath", containerPath);
-            resp.put("webDavURL", webdavURL);
+            resp.put("webDavURL", webdavURL.toString());
 
             return resp;
         }

--- a/src/org/labkey/signaldata/SignalDataController.java
+++ b/src/org/labkey/signaldata/SignalDataController.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.labkey.api.files.FileContentService.UPLOADED_FILE;
 
@@ -92,7 +93,7 @@ public class SignalDataController extends SpringActionController
             }
 
             resp.put("containerPath", containerPath);
-            resp.put("webDavURL", webdavURL.toString());
+            resp.put("webDavURL", Objects.toString(webdavURL, null));
 
             return resp;
         }
@@ -129,7 +130,7 @@ public class SignalDataController extends SpringActionController
     public class getSignalDataResourceAction extends MutatingApiAction<SignalDataResourceForm>
     {
         @Override
-        public ApiResponse execute(SignalDataResourceForm form, BindException errors) throws Exception
+        public ApiResponse execute(SignalDataResourceForm form, BindException errors)
         {
             String path = form.getPath();
             WebdavResource resource = WebdavService.get().lookup(path);
@@ -191,7 +192,7 @@ public class SignalDataController extends SpringActionController
                     }
                     catch (MalformedURLException e)
                     {
-                        throw new UnexpectedException(e);
+                        throw UnexpectedException.wrap(e);
                     }
                     catch (SQLException e)
                     {


### PR DESCRIPTION
#### Rationale
We are inconsistently encoding URIs in Strings and passing them around. Many codepaths end up double-encoding and then selectively decoding specific characters.

We can do better by using `URI` on the server and properly encoding throughout.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5961

#### Changes
- Switch to `URI` to make it clear what's being passed around
- Return encoded values in JSON and other responses
