### PR TITLE
Remove SupportedDatabases property now that default is PostgreSQL-only

### DIFF
--- a/module.properties
+++ b/module.properties
@@ -4,4 +4,3 @@ Description: A module defining general X/Y plottable assays and tools for workin
 URL: https://github.com/LabKey/signalData
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
-SupportedDatabases: pgsql


### PR DESCRIPTION
#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6067